### PR TITLE
Scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When you `Do` some work, you get a `Result`. A result is like a Rust future or a
 
 Calling `Then()` will block until the job is complete, and then give you the return value from the Runnable's `Run`. Cool, right?
 
-## Reactr has some very powerful capabilities, visit the [get started guide](./docs/getstarted.md) to learn more.
+## Reactr has some very powerful capabilities, visit the [Reactr guide](./docs/guide.md) to learn more.
 
 Reactr is being actively developed and has planned improvements, including optimized memory usage, library stability, data persistence, and more. Cheers!
 

--- a/rt/reactr.go
+++ b/rt/reactr.go
@@ -20,8 +20,8 @@ type JobFunc func(interface{}) *Result
 
 // Reactr represents the main control object
 type Reactr struct {
-	*scheduler
-	log *vlog.Logger
+	scheduler *scheduler
+	log       *vlog.Logger
 }
 
 // New returns a Reactr ready to accept Jobs
@@ -39,12 +39,18 @@ func New() *Reactr {
 
 // Do schedules a job to be worked on and returns a result object
 func (h *Reactr) Do(job Job) *Result {
-	return h.schedule(job)
+	return h.scheduler.schedule(job)
+}
+
+// Schedule adds a new Schedule to the instance, Reactr will 'watch' the Schedule
+// and Do any jobs when the Schedule indicates it's needed
+func (h *Reactr) Schedule(s Schedule) {
+	h.scheduler.watch(s)
 }
 
 // Handle registers a Runnable with the Reactr and returns a shortcut function to run those jobs
 func (h *Reactr) Handle(jobType string, runner Runnable, options ...Option) JobFunc {
-	h.handle(jobType, runner, options...)
+	h.scheduler.handle(jobType, runner, options...)
 
 	helper := func(data interface{}) *Result {
 		job := NewJob(jobType, data)
@@ -58,7 +64,7 @@ func (h *Reactr) Handle(jobType string, runner Runnable, options ...Option) JobF
 // HandleMsg registers a Runnable with the Reactr and triggers that job whenever the provided Grav pod
 // receives a message of a particular type.
 func (h *Reactr) HandleMsg(pod *grav.Pod, msgType string, runner Runnable, options ...Option) {
-	h.handle(msgType, runner, options...)
+	h.scheduler.handle(msgType, runner, options...)
 
 	h.Listen(pod, msgType)
 }

--- a/rt/schedule.go
+++ b/rt/schedule.go
@@ -1,0 +1,84 @@
+package rt
+
+import "time"
+
+/**
+This is not to be confused with the `scheduler` type, which is internal to the Reactr instance and actually schedules
+jobs for the registered workers. `Schedule` is an external type that allows the caller to define a literal schedule
+for jobs to run.
+**/
+
+// Schedule is a type that returns an *optional* job if there is something that should be scheduled.
+// Reactr will poll the Check() method at regular intervals to see if work is available.
+type Schedule interface {
+	Check() *Job
+	Done() bool
+}
+
+type everySchedule struct {
+	jobFunc func() Job
+	seconds int
+	last    *time.Time
+}
+
+// Every returns a Schedule that will schedule the job provided by jobFunc every x seconds
+func Every(seconds int, jobFunc func() Job) Schedule {
+	e := &everySchedule{
+		jobFunc: jobFunc,
+		seconds: seconds,
+	}
+
+	return e
+}
+
+func (e *everySchedule) Check() *Job {
+	now := time.Now()
+
+	// return a job if this schedule has never been checked OR the 'last' job was more than x seconds ago
+	if e.last == nil || time.Since(*e.last).Seconds() >= float64(e.seconds) {
+		e.last = &now
+
+		job := e.jobFunc()
+		return &job
+	}
+
+	return nil
+}
+
+func (e *everySchedule) Done() bool {
+	return false
+}
+
+type afterSchedule struct {
+	jobFunc func() Job
+	seconds int
+	created time.Time
+	done    bool
+}
+
+// After returns a schedule that will schedule the job provided by jobFunc one time x seconds after creation
+func After(seconds int, jobFunc func() Job) Schedule {
+	a := &afterSchedule{
+		jobFunc: jobFunc,
+		seconds: seconds,
+		created: time.Now(),
+		done:    false,
+	}
+
+	return a
+}
+
+func (a *afterSchedule) Check() *Job {
+	if time.Since(a.created).Seconds() >= float64(a.seconds) {
+		a.done = true
+		job := a.jobFunc()
+
+		return &job
+	}
+
+	return nil
+}
+
+func (a *afterSchedule) Done() bool {
+	return a.done
+}

--- a/rt/schedule_test.go
+++ b/rt/schedule_test.go
@@ -1,0 +1,35 @@
+package rt
+
+import (
+	"testing"
+
+	"github.com/suborbital/grav/testutil"
+)
+
+type counterRunner struct {
+	counter *testutil.AsyncCounter
+}
+
+func (c *counterRunner) Run(job Job, ctx *Ctx) (interface{}, error) {
+	c.counter.Count()
+
+	return nil, nil
+}
+
+func (c *counterRunner) OnChange(change ChangeEvent) error { return nil }
+
+func TestScheduleAfter(t *testing.T) {
+	r := New()
+
+	counter := testutil.NewAsyncCounter(10)
+
+	r.Handle("counter", &counterRunner{counter})
+
+	r.Schedule(After(2, func() Job {
+		return NewJob("counter", nil)
+	}))
+
+	if err := counter.Wait(1, 3); err != nil {
+		t.Error(err)
+	}
+}

--- a/rt/tester/main.go
+++ b/rt/tester/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/suborbital/reactr/rt"
+)
+
+func main() {
+	r := rt.New()
+
+	r.Handle("print", &printJob{})
+
+	r.Do(rt.NewJob("print", "start")).Discard()
+
+	r.Schedule(rt.Every(5, func() rt.Job {
+		return rt.NewJob("print", "every 5")
+	}))
+
+	r.Schedule(rt.After(7, func() rt.Job {
+		return rt.NewJob("print", "after 7")
+	}))
+
+	time.Sleep(time.Second * 25)
+}
+
+type printJob struct{}
+
+func (p *printJob) Run(job rt.Job, ctx *rt.Ctx) (interface{}, error) {
+	fmt.Println(job.String())
+	return nil, nil
+}
+
+func (p *printJob) OnChange(c rt.ChangeEvent) error { return nil }

--- a/rt/watcher.go
+++ b/rt/watcher.go
@@ -1,0 +1,72 @@
+package rt
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// watcher holds a set of schedules and "watches"
+// them for new jobs to send to the scheduler
+type watcher struct {
+	schedules    map[string]Schedule
+	scheduleFunc func(Job) *Result
+
+	lock      sync.RWMutex
+	startOnce sync.Once
+}
+
+func newWatcher(scheduleFunc func(Job) *Result) *watcher {
+	w := &watcher{
+		schedules:    map[string]Schedule{},
+		scheduleFunc: scheduleFunc,
+		lock:         sync.RWMutex{},
+		startOnce:    sync.Once{},
+	}
+
+	return w
+}
+
+func (w *watcher) watch(sched Schedule) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	w.schedules[uuid.New().String()] = sched
+
+	// we only want to start the ticker if something is actually set up
+	// to be scheduled, so we put it behind a sync.Once
+	w.startOnce.Do(func() {
+		go func() {
+			ticker := time.Tick(time.Second)
+
+			// loop forever and check each schedule for new jobs
+			// repeating every second
+			for {
+				remove := []string{}
+
+				w.lock.RLock()
+				for uuid, s := range w.schedules {
+					if s.Done() {
+						// set the schedule to be removed if it's done
+						remove = append(remove, uuid)
+					} else {
+						if job := s.Check(); job != nil {
+							// schedule the job and discard the result
+							w.scheduleFunc(*job).Discard()
+						}
+					}
+				}
+				w.lock.RUnlock()
+
+				w.lock.Lock()
+				for _, uuid := range remove {
+					delete(w.schedules, uuid)
+				}
+				w.lock.Unlock()
+
+				<-ticker
+			}
+		}()
+	})
+}


### PR DESCRIPTION
This PR adds the ability to add schedules to run jobs.

The `Schedule` interface allows you to create an object that defines a job schedule. `Every` and `After` are provided as basic schedule types.

```
r.Schedule(rt.Every(5, func() rt.Job {
	return rt.NewJob("print", "every 5")
}))
```
This runs a job every 5 seconds!