### PR TITLE
Add ability to deregister Runnables

### DIFF
--- a/rt/core.go
+++ b/rt/core.go
@@ -83,6 +83,25 @@ func (c *core) register(jobType string, runnable Runnable, caps Capabilities, op
 	}
 }
 
+func (c *core) deRegister(jobType string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	worker, exists := c.workers[jobType]
+	if !exists {
+		// make this a no-op
+		return nil
+	}
+
+	delete(c.workers, jobType)
+
+	if err := worker.stop(); err != nil {
+		return errors.Wrap(err, "failed to worker.stop")
+	}
+
+	return nil
+}
+
 func (c *core) watch(sched Schedule) {
 	c.watcher.watch(sched)
 }

--- a/rt/reactr.go
+++ b/rt/reactr.go
@@ -90,6 +90,11 @@ func (r *Reactr) RegisterWithCaps(jobType string, runner Runnable, caps Capabili
 	r.core.register(jobType, runner, caps, options...)
 }
 
+// DeRegister stops the workers for a given jobType and removes it
+func (r *Reactr) DeRegister(jobType string) error {
+	return r.core.deRegister(jobType)
+}
+
 // Listen causes Reactr to listen for messages of the given type and trigger the job of the same type.
 // The message's data is passed to the runnable as the job data.
 // The job's result is then emitted as a message. If an error occurs, it is logged and an error is sent.

--- a/rt/reactr_test.go
+++ b/rt/reactr_test.go
@@ -158,3 +158,33 @@ func TestPreWarmWorker(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestDeregisterWorker(t *testing.T) {
+	r := New()
+
+	r.Register("generic", generic{})
+
+	res := r.Do(r.Job("generic", "first"))
+
+	if res.UUID() == "" {
+		t.Error("result ID is empty")
+	}
+
+	result, err := res.Then()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if result.(string) != "last" {
+		t.Error("generic job failed, expected 'last', got", result.(string))
+	}
+
+	if err := r.DeRegister("generic"); err != nil {
+		t.Error(errors.Wrap(err, "failed to DeRegister"))
+	}
+
+	_, err = r.Do(r.Job("generic", "")).Then()
+	if err == nil {
+		t.Error("expected error but there was none")
+	}
+}

--- a/rt/runnable.go
+++ b/rt/runnable.go
@@ -9,6 +9,7 @@ type ChangeEvent int
 // ChangeTypeStart and others represent types of changes
 const (
 	ChangeTypeStart ChangeEvent = iota
+	ChangeTypeStop  ChangeEvent = iota
 )
 
 // Runnable describes something that is runnable

--- a/rwasm/wasmrunnable.go
+++ b/rwasm/wasmrunnable.go
@@ -118,9 +118,14 @@ func (w *Runner) Run(job rt.Job, ctx *rt.Ctx) (interface{}, error) {
 
 // OnChange runs when a worker starts using this Runnable
 func (w *Runner) OnChange(evt rt.ChangeEvent) error {
-	if evt == rt.ChangeTypeStart {
+	switch evt {
+	case rt.ChangeTypeStart:
 		if err := w.env.addInstance(); err != nil {
 			return errors.Wrap(err, "failed to addInstance")
+		}
+	case rt.ChangeTypeStop:
+		if err := w.env.removeInstance(); err != nil {
+			return errors.Wrap(err, "failed to removeInstance")
 		}
 	}
 


### PR DESCRIPTION
You can now call `r.DeRegister(jobType)` to remove a runnable from the instance.

Internally, this stops all the active workThreads (giving the internal runnable a chance to scale down if needed), and then removes it from the available workers.