### PR TITLE
Add more granular rules for Reactr capabilities

### DIFF
--- a/rcap/cache.go
+++ b/rcap/cache.go
@@ -13,7 +13,14 @@ var ErrCacheKeyNotFound = errors.New("key not found")
 // CacheConfig is configuration for the cache capability
 type CacheConfig struct {
 	Enabled     bool         `json:"enabled" yaml:"enabled"`
+	Rules       CacheRules   `json:"rules" yaml:"rules"`
 	RedisConfig *RedisConfig `json:"redis,omitempty" yaml:"redis,omitetmpty"`
+}
+
+type CacheRules struct {
+	AllowSet    bool `json:"allowSet" yaml:"allowSet"`
+	AllowGet    bool `json:"allowGet" yaml:"allowGet"`
+	AllowDelete bool `json:"allowDelete" yaml:"allowDelete"`
 }
 
 // CacheCapability gives Runnables access to a key/value cache
@@ -56,7 +63,7 @@ func SetupCache(config CacheConfig) CacheCapability {
 }
 
 func (m *memoryCache) Set(key string, val []byte, ttl int) error {
-	if !m.config.Enabled {
+	if !m.config.Enabled || !m.config.Rules.AllowSet {
 		return ErrCapabilityNotEnabled
 	}
 
@@ -87,7 +94,7 @@ func (m *memoryCache) Set(key string, val []byte, ttl int) error {
 }
 
 func (m *memoryCache) Get(key string) ([]byte, error) {
-	if !m.config.Enabled {
+	if !m.config.Enabled || !m.config.Rules.AllowGet {
 		return nil, ErrCapabilityNotEnabled
 	}
 
@@ -103,7 +110,7 @@ func (m *memoryCache) Get(key string) ([]byte, error) {
 }
 
 func (m *memoryCache) Delete(key string) error {
-	if !m.config.Enabled {
+	if !m.config.Enabled || !m.config.Rules.AllowDelete {
 		return ErrCapabilityNotEnabled
 	}
 
@@ -118,4 +125,14 @@ func (m *memoryCache) Delete(key string) error {
 	delete(m.values, key)
 
 	return nil
+}
+
+func defaultCacheRules() CacheRules {
+	c := CacheRules{
+		AllowSet:    true,
+		AllowGet:    true,
+		AllowDelete: true,
+	}
+
+	return c
 }

--- a/rcap/cache_redis.go
+++ b/rcap/cache_redis.go
@@ -36,7 +36,7 @@ func newRedisCache(config CacheConfig) *RedisCache {
 
 // Set sets a value in the cache
 func (r *RedisCache) Set(key string, val []byte, ttl int) error {
-	if !r.config.Enabled {
+	if !r.config.Enabled || !r.config.Rules.AllowSet {
 		return ErrCapabilityNotEnabled
 	}
 
@@ -51,7 +51,7 @@ func (r *RedisCache) Set(key string, val []byte, ttl int) error {
 
 // Get gets a value from the cache
 func (r *RedisCache) Get(key string) ([]byte, error) {
-	if !r.config.Enabled {
+	if !r.config.Enabled || !r.config.Rules.AllowGet {
 		return nil, ErrCapabilityNotEnabled
 	}
 
@@ -65,7 +65,7 @@ func (r *RedisCache) Get(key string) ([]byte, error) {
 
 // Delete deletes a key
 func (r *RedisCache) Delete(key string) error {
-	if !r.config.Enabled {
+	if !r.config.Enabled || !r.config.Rules.AllowDelete {
 		return ErrCapabilityNotEnabled
 	}
 

--- a/rcap/cache_test.go
+++ b/rcap/cache_test.go
@@ -1,0 +1,183 @@
+package rcap
+
+import "testing"
+
+func TestDefaultCache(t *testing.T) {
+	config := CacheConfig{
+		Enabled: true,
+		Rules: CacheRules{
+			AllowSet:    true,
+			AllowGet:    true,
+			AllowDelete: true,
+		},
+	}
+
+	cache := SetupCache(config)
+
+	t.Run("set enabled", func(t *testing.T) {
+		if err := cache.Set("foo", []byte("bar"), 0); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("get enabled", func(t *testing.T) {
+		val, err := cache.Get("foo")
+		if err != nil {
+			t.Error("error occurred, should not have")
+		}
+
+		if string(val) != "bar" {
+			t.Error("got incorrect value, expected 'bar': " + string(val))
+		}
+	})
+
+	t.Run("delete enabled", func(t *testing.T) {
+		if err := cache.Delete("foo"); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}
+
+func TestDisabledCache(t *testing.T) {
+	config := CacheConfig{
+		Enabled: false,
+		Rules: CacheRules{
+			AllowSet:    true,
+			AllowGet:    true,
+			AllowDelete: true,
+		},
+	}
+
+	cache := SetupCache(config)
+
+	t.Run("set disabled", func(t *testing.T) {
+		if err := cache.Set("foo", []byte("bar"), 0); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("get disabled", func(t *testing.T) {
+		val, err := cache.Get("foo")
+		if err == nil {
+			t.Error("error did not occur, should have")
+		}
+
+		if string(val) != "" {
+			t.Error("got incorrect value, expected '': " + string(val))
+		}
+	})
+
+	t.Run("delete disabled", func(t *testing.T) {
+		if err := cache.Delete("foo"); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+}
+
+func TestDisabledGet(t *testing.T) {
+	config := CacheConfig{
+		Enabled: true,
+		Rules: CacheRules{
+			AllowSet:    true,
+			AllowGet:    false,
+			AllowDelete: true,
+		},
+	}
+
+	cache := SetupCache(config)
+
+	t.Run("set enabled", func(t *testing.T) {
+		if err := cache.Set("foo", []byte("bar"), 0); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("get disabled", func(t *testing.T) {
+		val, err := cache.Get("foo")
+		if err == nil {
+			t.Error("error did not occur, should have")
+		}
+
+		if string(val) != "" {
+			t.Error("got incorrect value, expected '': " + string(val))
+		}
+	})
+
+	t.Run("delete enabled", func(t *testing.T) {
+		if err := cache.Delete("foo"); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}
+
+func TestDisabledSet(t *testing.T) {
+	config := CacheConfig{
+		Enabled: true,
+		Rules: CacheRules{
+			AllowSet:    false,
+			AllowGet:    true,
+			AllowDelete: true,
+		},
+	}
+
+	cache := SetupCache(config)
+
+	t.Run("set disabled", func(t *testing.T) {
+		if err := cache.Set("foo", []byte("bar"), 0); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("get enabled no value", func(t *testing.T) {
+		val, err := cache.Get("foo")
+		if err == nil {
+			t.Error("error did not occur, should have")
+		}
+
+		if string(val) != "" {
+			t.Error("got incorrect value, expected '': " + string(val))
+		}
+	})
+
+	t.Run("delete enabled no value", func(t *testing.T) {
+		if err := cache.Delete("foo"); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}
+
+func TestDisabledDelete(t *testing.T) {
+	config := CacheConfig{
+		Enabled: true,
+		Rules: CacheRules{
+			AllowSet:    true,
+			AllowGet:    true,
+			AllowDelete: false,
+		},
+	}
+
+	cache := SetupCache(config)
+
+	t.Run("set enabled", func(t *testing.T) {
+		if err := cache.Set("foo", []byte("bar"), 0); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("delete disabled", func(t *testing.T) {
+		if err := cache.Delete("foo"); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("get enabled", func(t *testing.T) {
+		val, err := cache.Get("foo")
+		if err != nil {
+			t.Error("error occurred, should not have")
+		}
+
+		if string(val) != "bar" {
+			t.Error("got incorrect value, expected 'bar': " + string(val))
+		}
+	})
+}

--- a/rcap/config.go
+++ b/rcap/config.go
@@ -34,9 +34,11 @@ func DefaultConfigWithLogger(logger *vlog.Logger) CapabilityConfig {
 		},
 		HTTP: &HTTPConfig{
 			Enabled: true,
+			Rules:   defaultHTTPRules(),
 		},
 		GraphQL: &GraphQLConfig{
 			Enabled: true,
+			Rules:   defaultHTTPRules(),
 		},
 		Auth: &AuthConfig{
 			Enabled: true,

--- a/rcap/config.go
+++ b/rcap/config.go
@@ -45,6 +45,7 @@ func DefaultConfigWithLogger(logger *vlog.Logger) CapabilityConfig {
 		},
 		Cache: &CacheConfig{
 			Enabled: true,
+			Rules:   defaultCacheRules(),
 		},
 		File: &FileConfig{
 			Enabled: true,

--- a/rcap/graphql.go
+++ b/rcap/graphql.go
@@ -82,6 +82,10 @@ func (g *defaultGraphQLClient) Do(auth AuthCapability, endpoint, query string) (
 		return nil, errors.Wrap(err, "failed to NewRequest")
 	}
 
+	if err := g.config.Rules.requestIsAllowed(req); err != nil {
+		return nil, errors.Wrap(err, "failed to requestIsAllowed")
+	}
+
 	req.Header.Add("Content-Type", "application/json")
 
 	authHeader := auth.HeaderForDomain(endpointURL.Host)

--- a/rcap/graphql.go
+++ b/rcap/graphql.go
@@ -13,7 +13,8 @@ import (
 
 // GraphQLConfig is configuration for the GraphQL capability
 type GraphQLConfig struct {
-	Enabled bool `json:"enabled" yaml:"enabled"`
+	Enabled bool      `json:"enabled" yaml:"enabled"`
+	Rules   HTTPRules `json:"rules" yaml:"rules"`
 }
 
 // GraphQLCapability is a GraphQL capability for Reactr Modules

--- a/rcap/http_rulefilter.go
+++ b/rcap/http_rulefilter.go
@@ -1,0 +1,113 @@
+package rcap
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrHttpDisallowed   = errors.New("requests to insecure HTTP endpoints is disallowed")
+	ErrIPsDisallowed    = errors.New("requests to IP addresses are disallowed")
+	ErrDomainDisallowed = errors.New("requests to this domain are disallowed")
+)
+
+// HTTPRules is a set of rules that governs use of the HTTP capability
+type HTTPRules struct {
+	AllowedDomains []string `json:"allowedDomains" yaml:"allowedDomains"`
+	BlockedDomains []string `json:"blockedDomains" yaml:"blockedDomains"`
+	AllowIPs       bool     `json:"allowIPs" yaml:"allowIPs"`
+	AllowHTTP      bool     `json:"allowHTTP" yaml:"allowHTTP"`
+}
+
+// requestIsAllowed returns a non-nil error if the provided request is not allowed to proceed
+func (h HTTPRules) requestIsAllowed(req *http.Request) error {
+	if !h.AllowHTTP {
+		if req.URL.Scheme == "http" {
+			return ErrHttpDisallowed
+		}
+	}
+
+	if !h.AllowIPs {
+		if net.ParseIP(req.URL.Host) != nil {
+			return ErrIPsDisallowed
+		}
+	}
+
+	// if AllowedDomains are listed, they take precednece over BlockedDomains
+	// (an explicit allowlist is more strict than a blocklist, so we default to that)
+	if len(h.AllowedDomains) > 0 {
+		// check each allowed domain, and if any match, return nil
+		for _, d := range h.AllowedDomains {
+			if matchesDomain(d, req.URL.Host) {
+				return nil
+			}
+		}
+
+		return ErrDomainDisallowed
+	} else if len(h.BlockedDomains) > 0 {
+		// check each blocked domain, if any match return an error
+		for _, d := range h.BlockedDomains {
+			if matchesDomain(d, req.URL.Host) {
+				return ErrDomainDisallowed
+			}
+		}
+	}
+
+	return nil
+}
+
+func matchesDomain(pattern, domain string) bool {
+	if pattern == "" && domain == "" {
+		return true
+	}
+
+	if pattern == "" || domain == "" {
+		return false
+	}
+
+	if pattern == domain {
+		return true
+	}
+
+	patternParts := strings.Split(pattern, ".")
+	domainParts := strings.Split(domain, ".")
+
+	if len(patternParts) > len(domainParts) {
+		return false
+	}
+
+	// iterate over the pattern and domain *backwards* to determine
+	// if the domain matches the pattern with wildcard support
+	j := len(patternParts) - 1
+	for i := len(domainParts) - 1; i >= 0; i-- {
+		p := patternParts[j]
+		d := domainParts[i]
+
+		if p == "*" || p == d {
+			// do nothing, they match
+		} else {
+			return false
+		}
+
+		if j > 0 {
+			j--
+		}
+	}
+
+	return true
+}
+
+// defaultHTTPRules returns the default rules with all requests allowed
+func defaultHTTPRules() HTTPRules {
+	h := HTTPRules{
+		AllowedDomains: []string{},
+		BlockedDomains: []string{},
+		AllowIPs:       true,
+		AllowHTTP:      true,
+	}
+
+	return h
+}

--- a/rcap/http_rulefilter_test.go
+++ b/rcap/http_rulefilter_test.go
@@ -35,7 +35,24 @@ func TestDefaultRules(t *testing.T) {
 
 func TestAllowedDomains(t *testing.T) {
 	rules := defaultHTTPRules()
-	rules.AllowedDomains = []string{"example.com", "another.com", "*.hello.com", "tomorrow.*", "10.*.12.13"}
+	rules.AllowedDomains = []string{"example.com", "another.com", "*.hello.com", "tomorrow.*", "10.*.12.13", "example.com:8080"}
+	
+	t.Run("example.com:8080 allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com:8080", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("example.com:8081 disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com:8081", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
 
 	t.Run("example.com allowed", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)

--- a/rcap/http_rulefilter_test.go
+++ b/rcap/http_rulefilter_test.go
@@ -1,0 +1,222 @@
+package rcap
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestDefaultRules(t *testing.T) {
+	rules := defaultHTTPRules()
+
+	t.Run("http allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("https allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "https://example.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("IP allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://10.11.12.13", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}
+
+func TestAllowedDomains(t *testing.T) {
+	rules := defaultHTTPRules()
+	rules.AllowedDomains = []string{"example.com", "another.com", "*.hello.com", "tomorrow.*", "10.*.12.13"}
+
+	t.Run("example.com allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("another.com allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://another.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("wildcard allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://goodbye.hello.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("double wildcard allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://goodmorning.goodbye.hello.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("end wildcard allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://tomorrow.eu", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("double end wildcard disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://tomorrow.co.uk", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("athird.com disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://athird.com", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("wildcard IP allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://10.11.12.13", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("IP disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://11.12.13.14", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+}
+
+func TestBlockedDomains(t *testing.T) {
+	rules := defaultHTTPRules()
+	rules.BlockedDomains = []string{"example.com", "another.com", "*.hello.com", "tomorrow.*"}
+
+	t.Run("example.com disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("another.com disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://another.com", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("wildcard disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://goodbye.hello.com", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("double wildcard disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://goodnight.goodbye.hello.com", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("end wildcard disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://tomorrow.eu", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("double end wildcard allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://tomorrow.co.uk", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("athird.com allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://athird.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+
+	t.Run("IP allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://10.11.12.13", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}
+
+func TestDisallowedIPs(t *testing.T) {
+	rules := defaultHTTPRules()
+	rules.AllowIPs = false
+
+	t.Run("IP disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://10.11.12.13", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("domain allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://friday.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}
+
+func TestDisallowHTTP(t *testing.T) {
+	rules := defaultHTTPRules()
+	rules.AllowHTTP = false
+
+	t.Run("HTTP disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
+	t.Run("HTTPS allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "https://friday.com", nil)
+
+		if err := rules.requestIsAllowed(req); err != nil {
+			t.Error("error occurred, should not have")
+		}
+	})
+}

--- a/rcap/httpclient.go
+++ b/rcap/httpclient.go
@@ -11,7 +11,8 @@ import (
 
 // HTTPConfig is configuration for the HTTP capability
 type HTTPConfig struct {
-	Enabled bool `json:"enabled" yaml:"enabled"`
+	Enabled bool      `json:"enabled" yaml:"enabled"`
+	Rules   HTTPRules `json:"rules" yaml:"rules"`
 }
 
 // HTTPCapability gives Runnables the ability to make HTTP requests

--- a/rcap/httpclient.go
+++ b/rcap/httpclient.go
@@ -49,6 +49,10 @@ func (h *httpClient) Do(auth AuthCapability, method, urlString string, body []by
 		return nil, errors.Wrap(err, "failed to NewRequest")
 	}
 
+	if err := h.config.Rules.requestIsAllowed(req); err != nil {
+		return nil, errors.Wrap(err, "failed to requestIsAllowed")
+	}
+
 	authHeader := auth.HeaderForDomain(urlObj.Host)
 	if authHeader != nil && authHeader.Value != "" {
 		headers.Add("Authorization", fmt.Sprintf("%s %s", authHeader.HeaderType, authHeader.Value))

--- a/rcap/logger.go
+++ b/rcap/logger.go
@@ -4,14 +4,13 @@ import "github.com/suborbital/vektor/vlog"
 
 // LoggerConfig is configuration for the logger capability
 type LoggerConfig struct {
-	Enabled bool `json:"enabled" yaml:"enabled"`
-
-	Logger *vlog.Logger `json:"-" yaml:"-"`
+	Enabled bool         `json:"enabled" yaml:"enabled"`
+	Logger  *vlog.Logger `json:"-" yaml:"-"`
 }
 
 // LoggerCapability provides a logger to Runnables
 type LoggerCapability interface {
-	Logger() *vlog.Logger
+	Log(level int32, msg string, scope interface{})
 }
 
 type loggerSource struct {
@@ -29,11 +28,22 @@ func DefaultLoggerSource(config LoggerConfig) LoggerCapability {
 	return l
 }
 
-// Logger returns the logger
-func (l *loggerSource) Logger() *vlog.Logger {
+// Log level int32, msg stringreturns the logger
+func (l *loggerSource) Log(level int32, msg string, scope interface{}) {
 	if !l.config.Enabled {
-		return nil
+		return
 	}
 
-	return l.log
+	scoped := l.log.CreateScoped(scope)
+
+	switch level {
+	case 1:
+		scoped.ErrorString(msg)
+	case 2:
+		scoped.Warn(msg)
+	case 4:
+		scoped.Debug(msg)
+	default:
+		scoped.Info(msg)
+	}
 }

--- a/rwasm/api_log.go
+++ b/rwasm/api_log.go
@@ -47,16 +47,5 @@ func log_msg(pointer int32, size int32, level int32, identifier int32) {
 		}
 	}
 
-	l := inst.ctx.LoggerSource.Logger().CreateScoped(scope)
-
-	switch level {
-	case 1:
-		l.ErrorString(string(msgBytes))
-	case 2:
-		l.Warn(string(msgBytes))
-	case 4:
-		l.Debug(string(msgBytes))
-	default:
-		l.Info(string(msgBytes))
-	}
+	inst.ctx.LoggerSource.Log(level, string(msgBytes), scope)
 }


### PR DESCRIPTION
This PR adds more granular config:
- HTTP and GraphQL request rules (domains, IP addresses, schemes, etc)
- Cache rules (enable/disable cache actions)
- Enable/disable logger works correctly now
- More to come