### PR TITLE
Small improvements to rcap package

### DIFF
--- a/rcap/authentication.go
+++ b/rcap/authentication.go
@@ -1,10 +1,5 @@
 package rcap
 
-import (
-	"os"
-	"strings"
-)
-
 // AuthCapability is a provider for various kinds of auth
 type AuthCapability interface {
 	HeaderForDomain(string) *AuthHeader
@@ -66,22 +61,13 @@ func (ap *defaultAuthProvider) HeaderForDomain(domain string) *AuthHeader {
 	return &header
 }
 
-// augmentHeadersFromEnv takes a an AuthHeader and replaces and `env()` values with their representative values from the environment
+// augmentHeadersFromEnv takes a an AuthHeader and replaces any
+// `env()` values with their representative values from the environment
 func augmentHeaderFromEnv(header AuthHeader) AuthHeader {
-	// turn env(SOME_HEADER_KEY) into SOME_HEADER_KEY
-	if strings.HasPrefix(header.Value, "env(") && strings.HasSuffix(header.Value, ")") {
-		headerKey := strings.TrimPrefix(header.Value, "env(")
-		headerKey = strings.TrimSuffix(headerKey, ")")
-
-		val := os.Getenv(headerKey)
-
-		augmentedHeader := AuthHeader{
-			HeaderType: header.HeaderType,
-			Value:      val,
-		}
-
-		return augmentedHeader
+	augmentedHeader := AuthHeader{
+		HeaderType: header.HeaderType,
+		Value:      AugmentedValFromEnv(header.Value),
 	}
 
-	return header
+	return augmentedHeader
 }

--- a/rcap/cache_redis.go
+++ b/rcap/cache_redis.go
@@ -21,9 +21,9 @@ type RedisConfig struct {
 
 func newRedisCache(config CacheConfig) *RedisCache {
 	client := redis.NewClient(&redis.Options{
-		Addr:     config.RedisConfig.ServerAddress,
-		Username: config.RedisConfig.Username,
-		Password: config.RedisConfig.Password,
+		Addr:     AugmentedValFromEnv(config.RedisConfig.ServerAddress),
+		Username: AugmentedValFromEnv(config.RedisConfig.Username),
+		Password: AugmentedValFromEnv(config.RedisConfig.Password),
 	})
 
 	rc := &RedisCache{

--- a/rcap/db.go
+++ b/rcap/db.go
@@ -69,14 +69,16 @@ type insertQueryResult struct {
 // NewSqlDatabase creates a new SQL database
 func NewSqlDatabase(config *DatabaseConfig) (DatabaseCapability, error) {
 	if !config.Enabled || config.ConnectionString == "" {
-		return nil, nil
+		return &SqlDatabase{config: config}, nil
 	}
 
 	if config.DBType != DBTypeMySQL && config.DBType != DBTypePostgres {
 		return nil, ErrDatabaseTypeInvalid
 	}
 
-	db, err := sqlx.Connect(config.DBType, config.ConnectionString)
+	augmentedConnString := AugmentedValFromEnv(config.ConnectionString)
+
+	db, err := sqlx.Connect(config.DBType, augmentedConnString)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to Connect")
 	}

--- a/rcap/env.go
+++ b/rcap/env.go
@@ -1,0 +1,19 @@
+package rcap
+
+import (
+	"os"
+	"strings"
+)
+
+func AugmentedValFromEnv(original string) string {
+	val := original
+
+	if strings.HasPrefix(original, "env(") && strings.HasSuffix(original, ")") {
+		envKey := strings.TrimPrefix(original, "env(")
+		envKey = strings.TrimSuffix(envKey, ")")
+
+		val = os.Getenv(envKey)
+	}
+
+	return val
+}

--- a/rcap/requesthandler.go
+++ b/rcap/requesthandler.go
@@ -109,7 +109,7 @@ func (r *requestHandler) GetField(fieldType int32, key string) ([]byte, error) {
 			return nil, ErrInvalidKey
 		}
 	default:
-		return nil, ErrInvalidFieldType
+		return nil, errors.Wrapf(ErrInvalidFieldType, "module requested field type %d", fieldType)
 	}
 
 	return []byte(val), nil

--- a/rcap/requesthandler.go
+++ b/rcap/requesthandler.go
@@ -18,7 +18,7 @@ const (
 var (
 	ErrReqNotSet        = errors.New("req is not set")
 	ErrInvalidFieldType = errors.New("invalid field type")
-	ErrInvalidKey       = errors.New("invalid key")
+	ErrKeyNotFound      = errors.New("key not found")
 )
 
 // RequestHandlerConfig is configuration for the request capability
@@ -76,7 +76,7 @@ func (r *requestHandler) GetField(fieldType int32, key string) ([]byte, error) {
 		case "body":
 			val = string(r.req.Body)
 		default:
-			return nil, ErrInvalidKey
+			return nil, ErrKeyNotFound
 		}
 	case RequestFieldTypeBody:
 		bodyVal, err := r.req.BodyField(key)
@@ -92,21 +92,21 @@ func (r *requestHandler) GetField(fieldType int32, key string) ([]byte, error) {
 		if ok {
 			val = header
 		} else {
-			return nil, ErrInvalidKey
+			return nil, ErrKeyNotFound
 		}
 	case RequestFieldTypeParams:
 		param, ok := r.req.Params[key]
 		if ok {
 			val = param
 		} else {
-			return nil, ErrInvalidKey
+			return nil, ErrKeyNotFound
 		}
 	case RequestFieldTypeState:
 		stateVal, ok := r.req.State[key]
 		if ok {
 			val = string(stateVal)
 		} else {
-			return nil, ErrInvalidKey
+			return nil, ErrKeyNotFound
 		}
 	default:
 		return nil, errors.Wrapf(ErrInvalidFieldType, "module requested field type %d", fieldType)
@@ -139,7 +139,7 @@ func (r *requestHandler) SetField(fieldType int32, key string, val string) error
 		case "body":
 			r.req.Body = []byte(val)
 		default:
-			return ErrInvalidKey
+			return ErrKeyNotFound
 		}
 	case RequestFieldTypeBody:
 		if err := r.req.SetBodyField(key, val); err != nil {

--- a/rwasm/api/api_abort.go
+++ b/rwasm/api/api_abort.go
@@ -29,7 +29,7 @@ func AbortHandler() runtime.HostFn {
 func return_abort(msgPtr int32, msgSize int32, filePtr int32, fileSize int32, lineNum int32, columnNum int32, ident int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(ident, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_cache.go
+++ b/rwasm/api/api_cache.go
@@ -25,7 +25,7 @@ func CacheSetHandler() runtime.HostFn {
 func cache_set(keyPointer int32, keySize int32, valPointer int32, valSize int32, ttl int32, identifier int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(identifier, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 
@@ -59,7 +59,7 @@ func CacheGetHandler() runtime.HostFn {
 func cache_get(keyPointer int32, keySize int32, identifier int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(identifier, true)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_db.go
+++ b/rwasm/api/api_db.go
@@ -24,7 +24,7 @@ func DBExecHandler() runtime.HostFn {
 func db_exec(queryType, namePointer, nameSize, identifier int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(identifier, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_graphql.go
+++ b/rwasm/api/api_graphql.go
@@ -26,7 +26,7 @@ func GraphQLQueryHandler() runtime.HostFn {
 func graphql_query(endpointPointer int32, endpointSize int32, queryPointer int32, querySize int32, identifier int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(identifier, true)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_http.go
+++ b/rwasm/api/api_http.go
@@ -52,7 +52,7 @@ func fetch_url(method int32, urlPointer int32, urlSize int32, bodyPointer int32,
 	// fetch writes the http response body into memory starting at returnBodyPointer, and the return value is a pointer to that memory
 	inst, err := runtime.InstanceForIdentifier(identifier, true)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_log.go
+++ b/rwasm/api/api_log.go
@@ -29,7 +29,7 @@ func LogMsgHandler() runtime.HostFn {
 func log_msg(pointer int32, size int32, level int32, identifier int32) {
 	inst, err := runtime.InstanceForIdentifier(identifier, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return
 	}
 

--- a/rwasm/api/api_request.go
+++ b/rwasm/api/api_request.go
@@ -23,7 +23,7 @@ func RequestGetFieldHandler() runtime.HostFn {
 func request_get_field(fieldType int32, keyPointer int32, keySize int32, identifier int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(identifier, true)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 
@@ -64,7 +64,7 @@ func RequestSetFieldHandler() runtime.HostFn {
 func request_set_field(fieldType int32, keyPointer int32, keySize int32, valPointer int32, valSize int32, identifier int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(identifier, true)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_resp.go
+++ b/rwasm/api/api_resp.go
@@ -25,7 +25,7 @@ func RespSetHeaderHandler() runtime.HostFn {
 func response_set_header(keyPointer int32, keySize int32, valPointer int32, valSize int32, ident int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(ident, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 

--- a/rwasm/api/api_result.go
+++ b/rwasm/api/api_result.go
@@ -23,7 +23,7 @@ func ReturnResultHandler() runtime.HostFn {
 func return_result(pointer int32, size int32, identifier int32) {
 	inst, err := runtime.InstanceForIdentifier(identifier, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return
 	}
 
@@ -50,7 +50,7 @@ func ReturnErrorHandler() runtime.HostFn {
 func return_error(code int32, pointer int32, size int32, identifier int32) {
 	inst, err := runtime.InstanceForIdentifier(identifier, false)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return
 	}
 

--- a/rwasm/api/api_static.go
+++ b/rwasm/api/api_static.go
@@ -22,7 +22,7 @@ func GetStaticFileHandler() runtime.HostFn {
 func get_static_file(namePtr int32, nameSize int32, ident int32) int32 {
 	inst, err := runtime.InstanceForIdentifier(ident, true)
 	if err != nil {
-		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: invalid identifier used, potential malicious activity"))
+		runtime.InternalLogger().Error(errors.Wrap(err, "[rwasm] alert: failed to InstanceForIdentifier"))
 		return -1
 	}
 


### PR DESCRIPTION
This is a collection of small improvements for the RCAP package:

- Handle nil DatabaseCapability better
- Allow the `env()` modifier to be used in more places
- Handle missing keys in headers, state, etc more elegantly