### PR TITLE
Use Hostname for httpFilter

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           gh repo clone suborbital/subo
           cd subo
-          gh pr checkout 120
           make subo
           cd ../
           rm -rf subo

--- a/rcap/http_rulefilter.go
+++ b/rcap/http_rulefilter.go
@@ -26,10 +26,8 @@ type HTTPRules struct {
 
 // requestIsAllowed returns a non-nil error if the provided request is not allowed to proceed
 func (h HTTPRules) requestIsAllowed(req *http.Request) error {
-	// remove square brackets from raw IPv6 host
-	cleanHost := strings.TrimSuffix(strings.TrimPrefix(req.URL.Host, "["), "]")
-
-	hosts := []string{cleanHost}
+	// Hostname removes port numbers as well as IPv6 [ and ]
+	hosts := []string{req.URL.Hostname()}
 
 	if !h.AllowHTTP {
 		if req.URL.Scheme == "http" {
@@ -38,7 +36,7 @@ func (h HTTPRules) requestIsAllowed(req *http.Request) error {
 	}
 
 	// determine if the passed-in host is an IP address
-	isRawIP := net.ParseIP(cleanHost) != nil
+	isRawIP := net.ParseIP(req.URL.Hostname()) != nil
 	if !h.AllowIPs && isRawIP {
 		return ErrIPsDisallowed
 	}

--- a/rcap/http_rulefilter_test.go
+++ b/rcap/http_rulefilter_test.go
@@ -321,6 +321,14 @@ func TestDisallowedLocal(t *testing.T) {
 		}
 	})
 
+	t.Run("Resolves to Private (with port) disallowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://local.suborbital.network:8081", nil)
+
+		if err := rules.requestIsAllowed(req); err == nil {
+			t.Error("error did not occur, should have")
+		}
+	})
+
 	t.Run("Private disallowed", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "http://localhost", nil)
 

--- a/rcap/http_rulefilter_test.go
+++ b/rcap/http_rulefilter_test.go
@@ -35,21 +35,13 @@ func TestDefaultRules(t *testing.T) {
 
 func TestAllowedDomains(t *testing.T) {
 	rules := defaultHTTPRules()
-	rules.AllowedDomains = []string{"example.com", "another.com", "*.hello.com", "tomorrow.*", "100.*.12.13", "example.com:8080"}
+	rules.AllowedDomains = []string{"example.com", "another.com", "*.hello.com", "tomorrow.*", "100.*.12.13"}
 
 	t.Run("example.com:8080 allowed", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "http://example.com:8080", nil)
 
 		if err := rules.requestIsAllowed(req); err != nil {
 			t.Error("error occurred, should not have:", err)
-		}
-	})
-
-	t.Run("example.com:8081 disallowed", func(t *testing.T) {
-		req, _ := http.NewRequest(http.MethodGet, "http://example.com:8081", nil)
-
-		if err := rules.requestIsAllowed(req); err == nil {
-			t.Error("error did not occur, should have")
 		}
 	})
 


### PR DESCRIPTION
This uses the standard Go `url.Hostname()` instead of our own parsing when checking URLs for filtering