### PR TITLE
Add HTTP port rules to HTTPFilter (#185)

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -20,3 +20,13 @@ func GenerateResultID() string {
 
 	return id
 }
+
+// ContainsInt returns true if value present in int slice
+func ContainsInt(value int, values []int) bool {
+	for _, p := range values {
+		if p == value {
+			return true
+		}
+	}
+	return false
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -11,3 +11,15 @@ func TestGenerateResultID(t *testing.T) {
 		t.Errorf("id has length %d, expected 24", len(id))
 	}
 }
+
+func TestContainsInt(t *testing.T) {
+	container := []int{1, 2, 3, 4}
+
+	if !ContainsInt(3, container) {
+		t.Errorf("expected value not found in container")
+	}
+
+	if ContainsInt(5, container) {
+		t.Errorf("should not have found value in container")
+	}
+}


### PR DESCRIPTION
closes #185 

Assumptions:

- Valid port numbers are to be enforced by the HTTP library either when constructing the URL or in response to perform a request against an illegal port number

- If allow/deny lists are not explicitly set allow all ports for backward compatibility 

- If a port exists in both the block and allow list deny the request


Notes: 

If we are open to API breaking changes I'd prefer to disallow non-standard ports by default 